### PR TITLE
Render null as empty

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,14 +3,19 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.424</version>
+    <version>4.33</version>
   </parent>
+
+  <properties>
+    <jenkins.version>2.289.1</jenkins.version>
+    <java.level>8</java.level>
+  </properties>
 
   <groupId>org.jenkins-ci.plugins</groupId>
   <artifactId>anything-goes-formatter</artifactId>
   <version>1.1-SNAPSHOT</version>
   <packaging>hpi</packaging>
-  <url>https://wiki.jenkins-ci.org/pages/viewpage.action?pageId=60915753</url>
+  <url>https://wiki.jenkins-ci.org/JENKINS/60915753.html</url>
 
   <!-- get every artifact through maven.glassfish.org, which proxies all the artifacts that we need -->
   <repositories>

--- a/src/main/java/org/jenkinsci/plugins/UnsafeMarkupFormatter.java
+++ b/src/main/java/org/jenkinsci/plugins/UnsafeMarkupFormatter.java
@@ -18,7 +18,9 @@ public class UnsafeMarkupFormatter extends MarkupFormatter {
 
     @Override
     public void translate(String markup, Writer output) throws IOException {
-        output.write(markup);
+        if (markup != null) {
+            output.write(markup);
+        }
     }
 
     @Extension

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <div>
   This plugin adds a markup formatter that's unsafe but allows more powerful
   HTML manipulation.

--- a/src/main/resources/org/jenkinsci/plugins/UnsafeMarkupFormatter/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/UnsafeMarkupFormatter/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:description>
     This markup formatter supports arbitrary HTML, including potentially dangerous elements like "script"


### PR DESCRIPTION
This PR prevents rendering of a null markup string as text `null`.

Since Jenkins 2.289.1 (at the latest), string properties (like the description of a job or parameter) when empty can be represented as a null reference instead of an empty string. The plugin is not prepared for this and therefore incorrectly renders the null reference as text "null".

Other improvements:
* parent plugin bumped to version 4.33
* minimum Jenkins version pumped to 2.289.1
* broken project URL fixed
* missing header added to jelly files