### PR TITLE
chore: add Renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:base"],
+  "automerge": false,
+  "platformAutomerge": true,
+  "automergeStrategy": "squash",
+  "labels": ["dependencies"],
+  "dependencyDashboard": true,
+  "packageRules": [
+    {
+      "description": "Auto-merge patch updates when checks pass",
+      "matchUpdateTypes": ["patch"],
+      "automerge": true
+    },
+    {
+      "description": "Do not auto-merge major updates",
+      "matchUpdateTypes": ["major"],
+      "automerge": false
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

- chore: add Renovate configuration

## Why is this change needed?

- Part of the plugin-by-plugin modernization rollout.
- Keeps each change isolated to simplify review and rollback.

## Testing done

- No Java runtime behavior changes in this PR.
- Verified changed files are present and committed correctly.
- CI checks on the PR are expected to validate the change in repository context.

## Risks / impact

- Low risk: repository configuration / metadata workflow change only.
- No known functional runtime risk for plugin execution.

## Related links

- Modernization tracker: `.dev-things/modernize-all-plugins.md`
