### PR TITLE
chore: add copilot repository instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,114 @@
+# Copilot Instructions — Lockable Resources Plugin
+
+This file tells GitHub Copilot (and other AI assistants) about the project's
+coding standards, PR requirements, and review checklist so they are applied
+automatically when generating code, commit messages, or PR descriptions.
+
+## Project overview
+
+Jenkins plugin that lets builds declare **lockable resources** (printers,
+phones, lab machines, etc.). If a resource is already locked, the build waits
+until it is free.
+
+- Language: **Java 17+** (Maven build, Jenkins HPI packaging)
+- Localization: managed via [Crowdin](https://crowdin.jenkins.io/lockable-resources-plugin); all strings live in `*.properties` files
+- UI examples: documented under `src/doc/examples/`
+
+## Issue linking
+
+- Reference a Jira issue as `JENKINS-XXXXX` with a link to `https://issues.jenkins.io/browse/JENKINS-XXXXX`.
+- Reference a GitHub issue as `#XXXXX`.
+- Use closing keywords (`Fixes #XXXXX`) when the PR fully resolves an issue.
+- Minor improvements do not require a tracking issue.
+- Bug fixes **should** have a tracking issue to facilitate backporting.
+- Major new features **must** have a tracking issue.
+
+## Commit & PR title conventions
+
+- The PR title is used as the **changelog entry** — write it in imperative mood
+  (e.g. "Add timeout parameter to lock step").
+- Follow the style of https://github.com/jenkins-infra/jenkins.io/blob/main/content/_data/changelogs/weekly.yml
+
+## Coding rules
+
+| Area | Rule |
+|------|------|
+| Internal-only public API | Annotate with `@NoExternalUse`; if called from Jelly, add `Used by {@code <panel>.jelly}` Javadoc |
+| New public classes/fields/methods | Annotate with `@Restricted` or add `@since TODO` Javadoc |
+| Deprecations | Use `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")` |
+| JavaScript | No inline scripts, no `eval()` — support future CSP directives (see [docs](https://www.jenkins.io/doc/developer/security/csp/)) |
+| Localizations | Always use `*.properties` files; English strings are mandatory for every new key |
+
+## Testing requirements
+
+- Every change **must** have automated tests, or the PR must explain why tests
+  are not feasible.
+- A green CI build alone does not prove the changed lines were executed —
+  describe the test scenario if coverage is missing.
+- Frontend changes: include before/after screenshots.
+- Refactoring: exercise the code before and after and confirm identical behavior.
+
+## PR labels (automatic)
+
+PRs are auto-labeled by two workflows:
+
+### File-based labels (`actions/labeler`)
+
+| Label | Paths |
+|-------|-------|
+| `java` | `src/main/java/**` |
+| `tests` | `src/test/**` |
+| `ci` | `.github/workflows/**`, `Jenkinsfile` |
+| `dependencies` | `pom.xml` |
+| `documentation` | `*.md`, `src/doc/**` |
+| `localization` | `src/main/resources/**/*.properties` |
+| `frontend` | `src/main/webapp/**`, `src/main/resources/**/*.jelly` |
+| `chore` | `.github/**`, `.gitignore`, `crowdin.yml` |
+
+### Release-drafter labels (`auto-label-pr.yml`)
+
+Added based on PR title/branch (for changelog generation):
+
+| Label | Trigger (title/branch) |
+|-------|------------------------|
+| `breaking` | Title contains "breaking" or "!:" |
+| `major-enhancement` | Title contains "major" + "feat/enhancement" |
+| `major-bug` | Title contains "major" + "fix/bug" |
+| `deprecated` | Title contains "deprecat" |
+| `removed` | Title contains "remove" |
+| `enhancement` | Title starts with "feat"/"add" or branch `feature/*` |
+| `bug` | Title starts with "fix" or branch `fix/*` |
+| `documentation` | Title starts with "docs" or branch `docs/*` |
+| `chore` | Title starts with "chore"/"ci:"/"build:" |
+| `refactor` | Title starts with "refactor" |
+| `security` | Title contains "security"/"cve-" |
+
+### Auto-approve countdown (owner/member PRs)
+
+For PRs by OWNER, MEMBER, or COLLABORATOR (non-draft), the label `merge-in-3-days-without-review`
+is automatically added to start the auto-approve countdown.
+
+## Dependency updates
+
+- Include links to external changelogs and, if possible, full diffs.
+- For new APIs or extension points, link to at least one consumer.
+
+## Upgrade guidelines
+
+- Only needed for breaking changes or changes requiring manual user action.
+- When applicable, set the `upgrade-guide-needed` label.
+
+## Maintainer merge checklist
+
+Before marking `ready-for-merge`:
+
+1. At least **one approval** with no outstanding change requests.
+2. All conversations resolved (or reviewer explicitly not blocking).
+3. PR title is an accurate, imperative-mood changelog entry.
+4. Correct release-drafter labels are set (see [label config](https://github.com/jenkinsci/.github/blob/ce466227c534c42820a597cb8e9cac2f2334920a/.github/release-drafter.yml#L9-L50)).
+5. Java code changes are covered by automated tests.
+
+## Interface changes
+
+Document any UI or pipeline-DSL changes as examples under
+[src/doc/examples/](src/doc/examples/readme.md).

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -12,7 +12,6 @@ The goal is consistent, safe, and reviewable contributions across plugins.
 
 ## Issue and PR linking
 
-- Link Jira issues as `JENKINS-XXXXX` when applicable.
 - Link GitHub issues as `#123`.
 - Use closing keywords (`Fixes #123`) only when fully resolved.
 - Minor maintenance tasks may not need an issue unless maintainers request one.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,114 +1,57 @@
-# Copilot Instructions — Lockable Resources Plugin
+# Copilot Instructions - Jenkins Plugin (Generic)
 
-This file tells GitHub Copilot (and other AI assistants) about the project's
-coding standards, PR requirements, and review checklist so they are applied
-automatically when generating code, commit messages, or PR descriptions.
+This file guides GitHub Copilot and AI assistants for Jenkins plugin repositories.
+The goal is consistent, safe, and reviewable contributions across plugins.
 
-## Project overview
+## Project baseline
 
-Jenkins plugin that lets builds declare **lockable resources** (printers,
-phones, lab machines, etc.). If a resource is already locked, the build waits
-until it is free.
+- Project type: Jenkins plugin (Maven, HPI packaging)
+- Main language: Java
+- UI technology may include Jelly, JavaScript, and CSS
+- Default branch is usually `master` unless the repo states otherwise
 
-- Language: **Java 17+** (Maven build, Jenkins HPI packaging)
-- Localization: managed via [Crowdin](https://crowdin.jenkins.io/lockable-resources-plugin); all strings live in `*.properties` files
-- UI examples: documented under `src/doc/examples/`
+## Issue and PR linking
 
-## Issue linking
+- Link Jira issues as `JENKINS-XXXXX` when applicable.
+- Link GitHub issues as `#123`.
+- Use closing keywords (`Fixes #123`) only when fully resolved.
+- Minor maintenance tasks may not need an issue unless maintainers request one.
 
-- Reference a Jira issue as `JENKINS-XXXXX` with a link to `https://issues.jenkins.io/browse/JENKINS-XXXXX`.
-- Reference a GitHub issue as `#XXXXX`.
-- Use closing keywords (`Fixes #XXXXX`) when the PR fully resolves an issue.
-- Minor improvements do not require a tracking issue.
-- Bug fixes **should** have a tracking issue to facilitate backporting.
-- Major new features **must** have a tracking issue.
+## Commit and PR title conventions
 
-## Commit & PR title conventions
-
-- The PR title is used as the **changelog entry** — write it in imperative mood
-  (e.g. "Add timeout parameter to lock step").
-- Follow the style of https://github.com/jenkins-infra/jenkins.io/blob/main/content/_data/changelogs/weekly.yml
+- PR title is used as changelog text: use imperative mood.
+- Keep titles clear and scoped to one change.
+- Prefer one logical change per PR.
 
 ## Coding rules
 
-| Area | Rule |
-|------|------|
-| Internal-only public API | Annotate with `@NoExternalUse`; if called from Jelly, add `Used by {@code <panel>.jelly}` Javadoc |
-| New public classes/fields/methods | Annotate with `@Restricted` or add `@since TODO` Javadoc |
-| Deprecations | Use `@Deprecated(since = "TODO")` or `@Deprecated(forRemoval = true, since = "TODO")` |
-| JavaScript | No inline scripts, no `eval()` — support future CSP directives (see [docs](https://www.jenkins.io/doc/developer/security/csp/)) |
-| Localizations | Always use `*.properties` files; English strings are mandatory for every new key |
+- Keep public API additions intentional and documented.
+- Mark internal-only APIs with Jenkins access restriction annotations when needed.
+- Avoid inline JavaScript and avoid `eval()`.
+- Add comments only where they improve maintainability.
+- Follow existing code style and plugin conventions.
 
-## Testing requirements
+## Localization
 
-- Every change **must** have automated tests, or the PR must explain why tests
-  are not feasible.
-- A green CI build alone does not prove the changed lines were executed —
-  describe the test scenario if coverage is missing.
-- Frontend changes: include before/after screenshots.
-- Refactoring: exercise the code before and after and confirm identical behavior.
+- Do not hardcode user-facing strings where localization is used.
+- Add English keys to `*.properties` files for new UI text.
 
-## PR labels (automatic)
+## Testing expectations
 
-PRs are auto-labeled by two workflows:
-
-### File-based labels (`actions/labeler`)
-
-| Label | Paths |
-|-------|-------|
-| `java` | `src/main/java/**` |
-| `tests` | `src/test/**` |
-| `ci` | `.github/workflows/**`, `Jenkinsfile` |
-| `dependencies` | `pom.xml` |
-| `documentation` | `*.md`, `src/doc/**` |
-| `localization` | `src/main/resources/**/*.properties` |
-| `frontend` | `src/main/webapp/**`, `src/main/resources/**/*.jelly` |
-| `chore` | `.github/**`, `.gitignore`, `crowdin.yml` |
-
-### Release-drafter labels (`auto-label-pr.yml`)
-
-Added based on PR title/branch (for changelog generation):
-
-| Label | Trigger (title/branch) |
-|-------|------------------------|
-| `breaking` | Title contains "breaking" or "!:" |
-| `major-enhancement` | Title contains "major" + "feat/enhancement" |
-| `major-bug` | Title contains "major" + "fix/bug" |
-| `deprecated` | Title contains "deprecat" |
-| `removed` | Title contains "remove" |
-| `enhancement` | Title starts with "feat"/"add" or branch `feature/*` |
-| `bug` | Title starts with "fix" or branch `fix/*` |
-| `documentation` | Title starts with "docs" or branch `docs/*` |
-| `chore` | Title starts with "chore"/"ci:"/"build:" |
-| `refactor` | Title starts with "refactor" |
-| `security` | Title contains "security"/"cve-" |
-
-### Auto-approve countdown (owner/member PRs)
-
-For PRs by OWNER, MEMBER, or COLLABORATOR (non-draft), the label `merge-in-3-days-without-review`
-is automatically added to start the auto-approve countdown.
+- Every non-trivial code change should include tests or a clear rationale when tests are not feasible.
+- For behavior changes, explain test scenarios in the PR description.
+- For UI changes, include screenshots when useful.
 
 ## Dependency updates
 
-- Include links to external changelogs and, if possible, full diffs.
-- For new APIs or extension points, link to at least one consumer.
+- Prefer small, isolated dependency PRs.
+- Include links to release notes/changelogs when helpful.
+- Flag breaking changes explicitly.
 
-## Upgrade guidelines
+## Maintainer pre-merge checklist
 
-- Only needed for breaking changes or changes requiring manual user action.
-- When applicable, set the `upgrade-guide-needed` label.
-
-## Maintainer merge checklist
-
-Before marking `ready-for-merge`:
-
-1. At least **one approval** with no outstanding change requests.
-2. All conversations resolved (or reviewer explicitly not blocking).
-3. PR title is an accurate, imperative-mood changelog entry.
-4. Correct release-drafter labels are set (see [label config](https://github.com/jenkinsci/.github/blob/ce466227c534c42820a597cb8e9cac2f2334920a/.github/release-drafter.yml#L9-L50)).
-5. Java code changes are covered by automated tests.
-
-## Interface changes
-
-Document any UI or pipeline-DSL changes as examples under
-[src/doc/examples/](src/doc/examples/readme.md).
+1. PR description matches actual changes.
+2. Linked issue(s) are correct when present.
+3. Required CI checks are green.
+4. At least one approval for non-trivial changes.
+5. No unresolved blocking comments.


### PR DESCRIPTION
Adds .github/copilot-instructions.md based on lockable-resources-plugin as a repository guidance baseline.