### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owners for all files in this plugin repository
+* @mPokornyETM

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-# Default owners for all files in this plugin repository
-* @mPokornyETM
+* @jenkinsci/anything-goes-formatter-plugin-developers


### PR DESCRIPTION
Adds a baseline .github/CODEOWNERS so reviews are automatically requested for repository changes.