### PR TITLE
chore: allow PR labels workflow on forks

### DIFF
--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -1,7 +1,7 @@
 name: PR Labels
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, edited, reopened, synchronize]
 
 permissions:
@@ -12,11 +12,7 @@ permissions:
 jobs:
   label:
     runs-on: ubuntu-latest
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     steps:
-      - name: Check out
-        uses: actions/checkout@v6
-
       - name: Run labeler
         uses: actions/labeler@v6
         with:
@@ -26,7 +22,7 @@ jobs:
   required:
     name: PR Labels - Required
     runs-on: ubuntu-latest
-    if: ${{ always() && github.event.pull_request.head.repo.full_name == github.repository }}
+    if: ${{ always() }}
     needs:
       - label
     steps:


### PR DESCRIPTION
Switches PR labeling to pull_request_target so forked PRs are labeled too, and removes checkout of PR head to avoid executing untrusted code. This keeps labeling functional for forks with a safe workflow design.